### PR TITLE
Store mcgymmy data in a separate data folder

### DIFF
--- a/src/main/java/jimmy/mcgymmy/model/UserPrefs.java
+++ b/src/main/java/jimmy/mcgymmy/model/UserPrefs.java
@@ -14,7 +14,7 @@ import jimmy.mcgymmy.commons.core.GuiSettings;
 public class UserPrefs implements ReadOnlyUserPrefs {
 
     private GuiSettings guiSettings = new GuiSettings();
-    private Path mcGymmyFilePath = Paths.get("mcgymmy.json");
+    private Path mcGymmyFilePath = Paths.get("data", "mcgymmy.json");
 
     /**
      * Creates a {@code UserPrefs} with default values.


### PR DESCRIPTION
I think we should store our `mcgymmy.json` file in a separate `data` folder so that it can be found easier