### PR TITLE
Remove duplicate check when creating tag

### DIFF
--- a/src/main/java/jimmy/mcgymmy/logic/parser/ParserUtil.java
+++ b/src/main/java/jimmy/mcgymmy/logic/parser/ParserUtil.java
@@ -118,12 +118,13 @@ public class ParserUtil {
      * @throws ParseException if the given {@code tag} is invalid.
      */
     public static Tag parseTag(String tag) throws ParseException {
-        requireNonNull(tag);
-        String trimmedTag = tag.trim();
-        if (!Tag.isValidTagName(trimmedTag)) {
-            throw new ParseException(Tag.MESSAGE_CONSTRAINTS);
+        try {
+            requireNonNull(tag);
+            String trimmedTag = tag.trim();
+            return new Tag(trimmedTag);
+        } catch (IllegalArgumentException e) {
+            throw new ParseException(e.getMessage());
         }
-        return new Tag(trimmedTag);
     }
 
     /**

--- a/src/main/java/jimmy/mcgymmy/logic/parser/ParserUtil.java
+++ b/src/main/java/jimmy/mcgymmy/logic/parser/ParserUtil.java
@@ -118,9 +118,9 @@ public class ParserUtil {
      * @throws ParseException if the given {@code tag} is invalid.
      */
     public static Tag parseTag(String tag) throws ParseException {
+        requireNonNull(tag);
+        String trimmedTag = tag.trim();
         try {
-            requireNonNull(tag);
-            String trimmedTag = tag.trim();
             return new Tag(trimmedTag);
         } catch (IllegalArgumentException e) {
             throw new ParseException(e.getMessage());


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/58925632/96330797-e3e68a00-108a-11eb-90dc-56430a42f20a.png)

The Tag class already has a function to check for validity itself, there is no point in duplicating the check again in `ParserUtil::parseTag`.
