### PR TITLE
Add undo command

### DIFF
--- a/src/main/java/jimmy/mcgymmy/logic/commands/EditCommand.java
+++ b/src/main/java/jimmy/mcgymmy/logic/commands/EditCommand.java
@@ -27,7 +27,8 @@ public class EditCommand extends Command {
     public static final String COMMAND_WORD = "edit";
     public static final String SHORT_DESCRIPTION = "Edit the selected food item.";
 
-    public static final String MESSAGE_EDIT_FOOD_SUCCESS = "Edited Food: %1$s";
+    public static final String MESSAGE_FOOD_NO_CHANGE = "The food item does not change:\n%1$s";
+    public static final String MESSAGE_EDIT_FOOD_SUCCESS = "Edited Food:\n%1$s";
     public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided.";
 
     private Parameter<Index> indexParameter = this.addParameter(
@@ -110,6 +111,10 @@ public class EditCommand extends Command {
         Set<Tag> tags = foodToEdit.getTags();
 
         Food editedFood = new Food(newName, newProtein, newFat, newCarb, tags, newDate);
+
+        if (foodToEdit.equals(editedFood)) {
+            return new CommandResult(String.format(MESSAGE_FOOD_NO_CHANGE, editedFood));
+        }
 
         model.setFood(index, editedFood);
         return new CommandResult(String.format(MESSAGE_EDIT_FOOD_SUCCESS, editedFood));

--- a/src/main/java/jimmy/mcgymmy/logic/commands/EditCommand.java
+++ b/src/main/java/jimmy/mcgymmy/logic/commands/EditCommand.java
@@ -112,7 +112,6 @@ public class EditCommand extends Command {
         Food editedFood = new Food(newName, newProtein, newFat, newCarb, tags, newDate);
 
         model.setFood(index, editedFood);
-        model.updateFilteredFoodList(Model.PREDICATE_SHOW_ALL_FOODS);
         return new CommandResult(String.format(MESSAGE_EDIT_FOOD_SUCCESS, editedFood));
     }
 }

--- a/src/main/java/jimmy/mcgymmy/logic/commands/TagCommand.java
+++ b/src/main/java/jimmy/mcgymmy/logic/commands/TagCommand.java
@@ -60,7 +60,6 @@ public class TagCommand extends Command {
 
         foodToTag.addTag(tag);
         model.setFood(index, foodToTag); //To refresh the card
-        model.updateFilteredFoodList(Model.PREDICATE_SHOW_ALL_FOODS);
         return new CommandResult(String.format(MESSAGE_SUCCESS, tag.tagName));
     }
 }

--- a/src/main/java/jimmy/mcgymmy/logic/commands/UnTagCommand.java
+++ b/src/main/java/jimmy/mcgymmy/logic/commands/UnTagCommand.java
@@ -60,7 +60,6 @@ public class UnTagCommand extends Command {
 
         foodToTag.removeTag(tag);
         model.setFood(index, foodToTag); //To refresh the card
-        model.updateFilteredFoodList(Model.PREDICATE_SHOW_ALL_FOODS);
         return new CommandResult(String.format(MESSAGE_SUCCESS, tag.tagName));
     }
 }

--- a/src/main/java/jimmy/mcgymmy/logic/commands/UndoCommand.java
+++ b/src/main/java/jimmy/mcgymmy/logic/commands/UndoCommand.java
@@ -7,8 +7,15 @@ public class UndoCommand extends Command {
     public static final String COMMAND_WORD = "undo";
     public static final String SHORT_DESCRIPTION = "Undo the last change to the food list.";
 
+    public static final String MESSAGE_UNDO_SUCCESS = "Successfully undo the last change in the food list.";
+    public static final String MESSAGE_NOT_UNDOABLE = "Cannot undo anymore.";
+
     @Override
     public CommandResult execute(Model model) throws CommandException {
-        return new CommandResult("undo command called");
+        if (!model.canUndo()) {
+            return new CommandResult(MESSAGE_NOT_UNDOABLE);
+        }
+        model.undo();
+        return new CommandResult(MESSAGE_UNDO_SUCCESS);
     }
 }

--- a/src/main/java/jimmy/mcgymmy/logic/commands/UndoCommand.java
+++ b/src/main/java/jimmy/mcgymmy/logic/commands/UndoCommand.java
@@ -1,0 +1,14 @@
+package jimmy.mcgymmy.logic.commands;
+
+import jimmy.mcgymmy.logic.commands.exceptions.CommandException;
+import jimmy.mcgymmy.model.Model;
+
+public class UndoCommand extends Command {
+    public static final String COMMAND_WORD = "undo";
+    public static final String SHORT_DESCRIPTION = "Undo the last change to the food list.";
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        return new CommandResult("undo command called");
+    }
+}

--- a/src/main/java/jimmy/mcgymmy/logic/commands/UndoCommand.java
+++ b/src/main/java/jimmy/mcgymmy/logic/commands/UndoCommand.java
@@ -1,6 +1,5 @@
 package jimmy.mcgymmy.logic.commands;
 
-import jimmy.mcgymmy.logic.commands.exceptions.CommandException;
 import jimmy.mcgymmy.model.Model;
 
 public class UndoCommand extends Command {
@@ -11,7 +10,7 @@ public class UndoCommand extends Command {
     public static final String MESSAGE_NOT_UNDOABLE = "Cannot undo anymore.";
 
     @Override
-    public CommandResult execute(Model model) throws CommandException {
+    public CommandResult execute(Model model) {
         if (!model.canUndo()) {
             return new CommandResult(MESSAGE_NOT_UNDOABLE);
         }

--- a/src/main/java/jimmy/mcgymmy/logic/parser/PrimitiveCommandParser.java
+++ b/src/main/java/jimmy/mcgymmy/logic/parser/PrimitiveCommandParser.java
@@ -24,6 +24,7 @@ import jimmy.mcgymmy.logic.commands.FindCommand;
 import jimmy.mcgymmy.logic.commands.ListCommand;
 import jimmy.mcgymmy.logic.commands.TagCommand;
 import jimmy.mcgymmy.logic.commands.UnTagCommand;
+import jimmy.mcgymmy.logic.commands.UndoCommand;
 import jimmy.mcgymmy.logic.parser.exceptions.ParseException;
 import jimmy.mcgymmy.logic.parser.parameter.AbstractParameter;
 import jimmy.mcgymmy.logic.parser.parameter.ParameterSet;
@@ -57,6 +58,7 @@ public class PrimitiveCommandParser {
         this.addCommand(ListCommand.COMMAND_WORD, ListCommand.SHORT_DESCRIPTION, ListCommand::new);
         this.addCommand(TagCommand.COMMAND_WORD, TagCommand.SHORT_DESCRIPTION, TagCommand::new);
         this.addCommand(UnTagCommand.COMMAND_WORD, UnTagCommand.SHORT_DESCRIPTION, UnTagCommand::new);
+        this.addCommand(UndoCommand.COMMAND_WORD, UndoCommand.SHORT_DESCRIPTION, UndoCommand::new);
     }
 
     /**

--- a/src/main/java/jimmy/mcgymmy/model/Model.java
+++ b/src/main/java/jimmy/mcgymmy/model/Model.java
@@ -82,6 +82,16 @@ public interface Model {
     void setFood(Index index, Food editedFood);
 
     /**
+     * Check if mcGymmy can undo
+     */
+    boolean canUndo();
+
+    /**
+     * Undo the previous change to mcGymmy
+     */
+    void undo();
+
+    /**
      * Returns an unmodifiable view of the filtered food list
      */
     ObservableList<Food> getFilteredFoodList();

--- a/src/main/java/jimmy/mcgymmy/model/ModelManager.java
+++ b/src/main/java/jimmy/mcgymmy/model/ModelManager.java
@@ -132,6 +132,7 @@ public class ModelManager implements Model {
     @Override
     public void undo() {
         if (canUndo()) {
+            assert mcGymmyStack.size() > 0 : "McGymmyStack is empty";
             mcGymmy.resetData(mcGymmyStack.pop());
             updateFilteredFoodList(PREDICATE_SHOW_ALL_FOODS);
         }

--- a/src/main/java/jimmy/mcgymmy/model/ModelManager.java
+++ b/src/main/java/jimmy/mcgymmy/model/ModelManager.java
@@ -22,7 +22,7 @@ import jimmy.mcgymmy.model.food.Food;
 public class ModelManager implements Model {
     private static final Logger logger = LogsCenter.getLogger(ModelManager.class);
 
-    private static final Stack<ReadOnlyMcGymmy> mcGymmyStack = new Stack<>();
+    private final Stack<ReadOnlyMcGymmy> mcGymmyStack = new Stack<>();
 
     private final McGymmy mcGymmy;
     private final UserPrefs userPrefs;
@@ -148,7 +148,7 @@ public class ModelManager implements Model {
     }
 
     @Override
-    public void  updateFilteredFoodList(Predicate<Food> predicate) {
+    public void updateFilteredFoodList(Predicate<Food> predicate) {
         requireNonNull(predicate);
         filteredFoodItems.setPredicate(predicate);
     }

--- a/src/main/java/jimmy/mcgymmy/model/ModelManager.java
+++ b/src/main/java/jimmy/mcgymmy/model/ModelManager.java
@@ -90,7 +90,7 @@ public class ModelManager implements Model {
 
     @Override
     public void setMcGymmy(ReadOnlyMcGymmy mcGymmy) {
-        mcGymmyStack.push(new McGymmy(this.mcGymmy));
+        addCurrentStateToHistory();
         this.mcGymmy.resetData(mcGymmy);
     }
 
@@ -102,13 +102,13 @@ public class ModelManager implements Model {
 
     @Override
     public void deleteFood(Index index) {
-        mcGymmyStack.push(new McGymmy(mcGymmy));
+        addCurrentStateToHistory();
         mcGymmy.removeFood(index);
     }
 
     @Override
     public void addFood(Food food) {
-        mcGymmyStack.push(new McGymmy(mcGymmy));
+        addCurrentStateToHistory();
         mcGymmy.addFood(food);
         updateFilteredFoodList(PREDICATE_SHOW_ALL_FOODS);
     }
@@ -116,7 +116,7 @@ public class ModelManager implements Model {
     @Override
     public void setFood(Index index, Food editedFood) {
         CollectionUtil.requireAllNonNull(index, editedFood);
-        mcGymmyStack.push(new McGymmy(mcGymmy));
+        addCurrentStateToHistory();
         mcGymmy.setFood(index, editedFood);
         updateFilteredFoodList(PREDICATE_SHOW_ALL_FOODS);
     }
@@ -135,6 +135,10 @@ public class ModelManager implements Model {
             mcGymmy.resetData(mcGymmyStack.pop());
             updateFilteredFoodList(PREDICATE_SHOW_ALL_FOODS);
         }
+    }
+
+    private void addCurrentStateToHistory() {
+        mcGymmyStack.push(new McGymmy(mcGymmy));
     }
 
     //=========== Filtered Food List Accessors =============================================================

--- a/src/main/java/jimmy/mcgymmy/model/ModelManager.java
+++ b/src/main/java/jimmy/mcgymmy/model/ModelManager.java
@@ -118,6 +118,7 @@ public class ModelManager implements Model {
         CollectionUtil.requireAllNonNull(index, editedFood);
         mcGymmyStack.push(new McGymmy(mcGymmy));
         mcGymmy.setFood(index, editedFood);
+        updateFilteredFoodList(PREDICATE_SHOW_ALL_FOODS);
     }
 
     @Override

--- a/src/main/java/jimmy/mcgymmy/model/ModelManager.java
+++ b/src/main/java/jimmy/mcgymmy/model/ModelManager.java
@@ -3,6 +3,7 @@ package jimmy.mcgymmy.model;
 import static java.util.Objects.requireNonNull;
 
 import java.nio.file.Path;
+import java.util.Stack;
 import java.util.function.Predicate;
 import java.util.logging.Logger;
 
@@ -20,6 +21,8 @@ import jimmy.mcgymmy.model.food.Food;
  */
 public class ModelManager implements Model {
     private static final Logger logger = LogsCenter.getLogger(ModelManager.class);
+
+    private static final Stack<ReadOnlyMcGymmy> mcGymmyStack = new Stack<>();
 
     private final McGymmy mcGymmy;
     private final UserPrefs userPrefs;
@@ -87,6 +90,7 @@ public class ModelManager implements Model {
 
     @Override
     public void setMcGymmy(ReadOnlyMcGymmy mcGymmy) {
+        mcGymmyStack.push(new McGymmy(this.mcGymmy));
         this.mcGymmy.resetData(mcGymmy);
     }
 
@@ -98,11 +102,13 @@ public class ModelManager implements Model {
 
     @Override
     public void deleteFood(Index index) {
+        mcGymmyStack.push(new McGymmy(mcGymmy));
         mcGymmy.removeFood(index);
     }
 
     @Override
     public void addFood(Food food) {
+        mcGymmyStack.push(new McGymmy(mcGymmy));
         mcGymmy.addFood(food);
         updateFilteredFoodList(PREDICATE_SHOW_ALL_FOODS);
     }
@@ -110,8 +116,24 @@ public class ModelManager implements Model {
     @Override
     public void setFood(Index index, Food editedFood) {
         CollectionUtil.requireAllNonNull(index, editedFood);
-
+        mcGymmyStack.push(new McGymmy(mcGymmy));
         mcGymmy.setFood(index, editedFood);
+    }
+
+    @Override
+    public boolean canUndo() {
+        return !mcGymmyStack.empty();
+    }
+
+    /**
+     * Undo the previous change to mcGymmy
+     */
+    @Override
+    public void undo() {
+        if (canUndo()) {
+            mcGymmy.resetData(mcGymmyStack.pop());
+            updateFilteredFoodList(PREDICATE_SHOW_ALL_FOODS);
+        }
     }
 
     //=========== Filtered Food List Accessors =============================================================
@@ -126,7 +148,7 @@ public class ModelManager implements Model {
     }
 
     @Override
-    public void updateFilteredFoodList(Predicate<Food> predicate) {
+    public void  updateFilteredFoodList(Predicate<Food> predicate) {
         requireNonNull(predicate);
         filteredFoodItems.setPredicate(predicate);
     }

--- a/src/main/java/jimmy/mcgymmy/model/food/Food.java
+++ b/src/main/java/jimmy/mcgymmy/model/food/Food.java
@@ -148,7 +148,7 @@ public class Food {
     // name + PCF details + total calories
     @Override
     public String toString() {
-        return "Food:" + this.getName() + "\n"
+        return "Food: " + this.getName() + "\n"
                 + "protein: " + protein.getAmount() + "\n"
                 + "carbs: " + carbs.getAmount() + "\n"
                 + "fat: " + fat.getAmount() + "\n";

--- a/src/main/java/jimmy/mcgymmy/storage/JsonSerializableMcGymmy.java
+++ b/src/main/java/jimmy/mcgymmy/storage/JsonSerializableMcGymmy.java
@@ -49,9 +49,6 @@ class JsonSerializableMcGymmy {
         McGymmy mcGymmy = new McGymmy();
         for (JsonAdaptedFood jsonAdaptedFood : food) {
             Food food = jsonAdaptedFood.toModelType();
-            if (mcGymmy.hasFood(food)) {
-                throw new IllegalValueException(MESSAGE_DUPLICATE_FOOD);
-            }
             mcGymmy.addFood(food);
         }
         return mcGymmy;

--- a/src/test/java/jimmy/mcgymmy/logic/commands/AddCommandTest.java
+++ b/src/test/java/jimmy/mcgymmy/logic/commands/AddCommandTest.java
@@ -184,6 +184,17 @@ public class AddCommandTest {
         }
 
         @Override
+        public boolean canUndo() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+
+        @Override
+        public void undo() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
         public ObservableList<Food> getFilteredFoodList() {
             throw new AssertionError("This method should not be called.");
         }

--- a/src/test/java/jimmy/mcgymmy/logic/commands/EditCommandTest.java
+++ b/src/test/java/jimmy/mcgymmy/logic/commands/EditCommandTest.java
@@ -167,10 +167,30 @@ public class EditCommandTest {
     }
 
     @Test
+    public void execute_editedFoodSameAsInitialFood_returnsFoodNoChangeMessage() {
+        Food foodInList =
+                model.getMcGymmy().getFoodList().get(INDEX_FIRST_FOOD.getZeroBased());
+        EditCommand editCommand = new EditCommand();
+        editCommand.setParameters(
+                new CommandParserTestUtil.ParameterStub<>("", INDEX_FIRST_FOOD),
+                new CommandParserTestUtil.OptionalParameterStub<>("n"),
+                new CommandParserTestUtil.OptionalParameterStub<>("p", foodInList.getProtein()),
+                new CommandParserTestUtil.OptionalParameterStub<>("f"),
+                new CommandParserTestUtil.OptionalParameterStub<>("c"),
+                new CommandParserTestUtil.OptionalParameterStub<>("d")
+        );
+
+        String expectedMessage = String.format(EditCommand.MESSAGE_FOOD_NO_CHANGE, foodInList);
+        Model expectedModel = new ModelManager(new McGymmy(model.getMcGymmy()), new UserPrefs());
+        expectedModel.setFood(INDEX_FIRST_FOOD, foodInList);
+        assertCommandSuccess(editCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
     public void execute_duplicateFoodFilteredList_success() {
         showFoodAtIndex(model, INDEX_FIRST_FOOD);
 
-        // edit food in filtered list into a duplicate in address book
+        // edit food in filtered list into a duplicate in fridge
         Food foodInList =
                 model.getMcGymmy().getFoodList().get(INDEX_SECOND_FOOD.getZeroBased());
         EditCommand editCommand = new EditCommand();

--- a/src/test/java/jimmy/mcgymmy/logic/commands/UndoCommandTest.java
+++ b/src/test/java/jimmy/mcgymmy/logic/commands/UndoCommandTest.java
@@ -1,0 +1,45 @@
+package jimmy.mcgymmy.logic.commands;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+import jimmy.mcgymmy.model.ModelManager;
+
+/**
+ * Contains unit tests for UndoCommand.
+ */
+public class UndoCommandTest {
+    private class CanUndoModelStub extends ModelManager {
+        @Override
+        public boolean canUndo() {
+            return true;
+        }
+
+        @Override
+        public void undo() {
+            // do nothing (to prevent EmptyStackException)
+        }
+    }
+
+    private class CannotUndoModelStub extends ModelManager {
+        @Override
+        public boolean canUndo() {
+            return false;
+        }
+    }
+
+    @Test
+    public void execute_canUndo_returnsUndoSuccessfulMessage() {
+        UndoCommand command = new UndoCommand();
+        CommandResult commandResult = command.execute(new CanUndoModelStub());
+        assertEquals(new CommandResult(UndoCommand.MESSAGE_UNDO_SUCCESS), commandResult);
+    }
+
+    @Test
+    public void execute_cannotUndo_returnsCannotUndoAnyMoreMessage() {
+        UndoCommand command = new UndoCommand();
+        CommandResult commandResult = command.execute(new CannotUndoModelStub());
+        assertEquals(new CommandResult(UndoCommand.MESSAGE_NOT_UNDOABLE), commandResult);
+    }
+}

--- a/src/test/java/jimmy/mcgymmy/logic/commands/UndoCommandTest.java
+++ b/src/test/java/jimmy/mcgymmy/logic/commands/UndoCommandTest.java
@@ -1,6 +1,7 @@
 package jimmy.mcgymmy.logic.commands;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
 
@@ -11,6 +12,7 @@ import jimmy.mcgymmy.model.ModelManager;
  */
 public class UndoCommandTest {
     private class CanUndoModelStub extends ModelManager {
+        private boolean hasBeenUndoed = false;
         @Override
         public boolean canUndo() {
             return true;
@@ -18,7 +20,11 @@ public class UndoCommandTest {
 
         @Override
         public void undo() {
-            // do nothing (to prevent EmptyStackException)
+            hasBeenUndoed = true;
+        }
+
+        public boolean isUndoed() {
+            return hasBeenUndoed;
         }
     }
 
@@ -32,8 +38,10 @@ public class UndoCommandTest {
     @Test
     public void execute_canUndo_returnsUndoSuccessfulMessage() {
         UndoCommand command = new UndoCommand();
-        CommandResult commandResult = command.execute(new CanUndoModelStub());
+        CanUndoModelStub model = new CanUndoModelStub();
+        CommandResult commandResult = command.execute(model);
         assertEquals(new CommandResult(UndoCommand.MESSAGE_UNDO_SUCCESS), commandResult);
+        assertTrue(model.isUndoed());
     }
 
     @Test

--- a/src/test/java/jimmy/mcgymmy/model/food/FoodTest.java
+++ b/src/test/java/jimmy/mcgymmy/model/food/FoodTest.java
@@ -55,12 +55,12 @@ public class FoodTest {
 
     @Test
     public void toStringTest() {
-        String expected1 = "Food:test food\n"
+        String expected1 = "Food: test food\n"
                 + "protein: 2\n"
                 + "carbs: 3\n"
                 + "fat: 4\n";
         assertEquals(COMPARED_FOOD.toString(), expected1);
-        String expected2 = "Food:test food2\n"
+        String expected2 = "Food: test food2\n"
                 + "protein: 100\n"
                 + "carbs: 20\n"
                 + "fat: 10\n";

--- a/src/test/java/jimmy/mcgymmy/storage/JsonSerializableMcGymmyTest.java
+++ b/src/test/java/jimmy/mcgymmy/storage/JsonSerializableMcGymmyTest.java
@@ -35,13 +35,4 @@ public class JsonSerializableMcGymmyTest {
                 JsonSerializableMcGymmy.class).get();
         assertThrows(IllegalValueException.class, dataFromFile::toModelType);
     }
-
-    @Test
-    public void toModelType_duplicateFood_throwsIllegalValueException() throws Exception {
-        JsonSerializableMcGymmy dataFromFile = JsonUtil.readJsonFile(DUPLICATE_FOOD_FILE,
-                JsonSerializableMcGymmy.class).get();
-        assertThrows(IllegalValueException.class, JsonSerializableMcGymmy.MESSAGE_DUPLICATE_FOOD,
-                dataFromFile::toModelType);
-    }
-
 }


### PR DESCRIPTION
* Add an undo command that undoes the previous change to the list. 
I think saving the state of the food list only when there is a change is more reasonable because if we save the state whenever a command is called, the app will look like it doesn't react if the user types in a lot of `list` commands, followed by a list of `undo` commands

* Add test cases for this feature

close #74 