### PR TITLE
Update undo command to undo all commands except help

### DIFF
--- a/src/main/java/jimmy/mcgymmy/logic/commands/AddCommand.java
+++ b/src/main/java/jimmy/mcgymmy/logic/commands/AddCommand.java
@@ -89,7 +89,7 @@ public class AddCommand extends Command {
 
         if (this.tagParameter.getValue().isPresent()) {
             Tag newTag = this.tagParameter.getValue().get();
-            toAdd.addTag(newTag);
+            toAdd = toAdd.addTag(newTag);
         }
 
         model.addFood(toAdd);

--- a/src/main/java/jimmy/mcgymmy/logic/commands/TagCommand.java
+++ b/src/main/java/jimmy/mcgymmy/logic/commands/TagCommand.java
@@ -54,12 +54,12 @@ public class TagCommand extends Command {
         Food foodToTag = lastShownList.get(index.getZeroBased());
         Tag tag = tagParameter.consume();
 
-        if (foodToTag.getTags().contains(tag)) {
+        if (foodToTag.hasTag(tag)) {
             throw new CommandException(String.format(MESSAGE_DUPLICATE_TAG, tag.tagName, foodToTag.getName().fullName));
         }
 
-        foodToTag.addTag(tag);
-        model.setFood(index, foodToTag); //To refresh the card
+        Food newFood = foodToTag.addTag(tag);
+        model.setFood(index, newFood); //To refresh the card
         return new CommandResult(String.format(MESSAGE_SUCCESS, tag.tagName));
     }
 }

--- a/src/main/java/jimmy/mcgymmy/logic/commands/UnTagCommand.java
+++ b/src/main/java/jimmy/mcgymmy/logic/commands/UnTagCommand.java
@@ -54,12 +54,12 @@ public class UnTagCommand extends Command {
         Food foodToTag = lastShownList.get(index.getZeroBased());
         Tag tag = tagParameter.consume();
 
-        if (!foodToTag.getTags().contains(tag)) {
+        if (!foodToTag.hasTag(tag)) {
             throw new CommandException(String.format(MESSAGE_NOT_FOUND_TAG, tag.tagName, foodToTag.getName().fullName));
         }
 
-        foodToTag.removeTag(tag);
-        model.setFood(index, foodToTag); //To refresh the card
+        Food newFood = foodToTag.removeTag(tag);
+        model.setFood(index, newFood); //To refresh the card
         return new CommandResult(String.format(MESSAGE_SUCCESS, tag.tagName));
     }
 }

--- a/src/main/java/jimmy/mcgymmy/model/History.java
+++ b/src/main/java/jimmy/mcgymmy/model/History.java
@@ -1,0 +1,48 @@
+package jimmy.mcgymmy.model;
+
+import java.util.EmptyStackException;
+import java.util.Stack;
+import java.util.function.Predicate;
+
+import javafx.util.Pair;
+import jimmy.mcgymmy.model.food.Food;
+
+class History {
+    private final Stack<Pair<McGymmy, Predicate<Food>>> stack;
+
+    History() {
+        stack = new Stack<>();
+    }
+
+    private boolean checkIfSameWithPreviousState(McGymmy otherMcGymmy, Predicate<Food> otherPredicate) {
+        if (stack.empty()) {
+            return false;
+        }
+
+        McGymmy mcGymmy = stack.peek().getKey();
+        Predicate<Food> predicate = stack.peek().getValue();
+
+        boolean isSameMcGymmy = otherMcGymmy.equals(mcGymmy);
+        boolean isSamePredicate = otherPredicate.equals(predicate);
+        return isSameMcGymmy && isSamePredicate;
+    }
+
+    void save(ModelManager modelManager) {
+        McGymmy mcGymmy = new McGymmy(modelManager.getMcGymmy());
+        Predicate<Food> predicate = modelManager.getFilterPredicate();
+        boolean isSameWithPreviousState = checkIfSameWithPreviousState(mcGymmy, predicate);
+        if (!isSameWithPreviousState) {
+            stack.push(new Pair<>(mcGymmy, predicate));
+        }
+    }
+
+    boolean empty() {
+        return stack.empty();
+    }
+
+    Pair<McGymmy, Predicate<Food>> pop() throws EmptyStackException {
+        assert !stack.empty() : "History is empty";
+        return stack.pop();
+    }
+}
+

--- a/src/main/java/jimmy/mcgymmy/model/Model.java
+++ b/src/main/java/jimmy/mcgymmy/model/Model.java
@@ -53,7 +53,7 @@ public interface Model {
     ReadOnlyMcGymmy getMcGymmy();
 
     /**
-     * Set McGymmy
+     * Sets McGymmy
      */
     void setMcGymmy(ReadOnlyMcGymmy mcGymmy);
 
@@ -72,7 +72,6 @@ public interface Model {
 
     /**
      * Adds the given food.
-     * {@code food} must not already exist in mcgymmy.
      */
     void addFood(Food food);
 

--- a/src/main/java/jimmy/mcgymmy/model/ModelManager.java
+++ b/src/main/java/jimmy/mcgymmy/model/ModelManager.java
@@ -93,6 +93,10 @@ public class ModelManager implements Model {
         return mcGymmy;
     }
 
+    /**
+     * Sets McGymmy and saves the current state to the history
+     * @param mcGymmy
+     */
     @Override
     public void setMcGymmy(ReadOnlyMcGymmy mcGymmy) {
         saveCurrentStateToHistory();
@@ -106,6 +110,12 @@ public class ModelManager implements Model {
         return mcGymmy.hasFood(food);
     }
 
+    /**
+     * Deletes the given food and saves the current state to the history
+     * The index must be valid
+     *
+     * @param index
+     */
     @Override
     public void deleteFood(Index index) {
         logger.fine("Delete food at index: " + index.getOneBased());
@@ -113,6 +123,9 @@ public class ModelManager implements Model {
         mcGymmy.removeFood(index);
     }
 
+    /**
+     * Adds the given food and saves the current state to the history
+     */
     @Override
     public void addFood(Food food) {
         logger.fine("Add food:\n" + food.toString());
@@ -121,6 +134,10 @@ public class ModelManager implements Model {
         updateFilterPredicate(PREDICATE_SHOW_ALL_FOODS);
     }
 
+    /**
+     * Replaces the given food {@code target} with {@code editedFood}, and saves the current state to the history
+     * The index must be valid
+     */
     @Override
     public void setFood(Index index, Food editedFood) {
         CollectionUtil.requireAllNonNull(index, editedFood);
@@ -136,7 +153,7 @@ public class ModelManager implements Model {
     }
 
     /**
-     * Undo the previous change to mcGymmy
+     * Undo the previous change to mcGymmy, remove that state from history
      */
     @Override
     public void undo() {
@@ -184,8 +201,10 @@ public class ModelManager implements Model {
     public void updateFilteredFoodList(Predicate<Food> predicate) {
         requireNonNull(predicate);
         logger.fine("Update predicate for filtered food list");
-        saveCurrentStateToHistory();
-        updateFilterPredicate(predicate);
+        if (!predicate.equals(filterPredicate)) {
+            saveCurrentStateToHistory();
+            updateFilterPredicate(predicate);
+        }
     }
 
     private void updateFilterPredicate(Predicate<Food> predicate) {

--- a/src/main/java/jimmy/mcgymmy/model/ModelManager.java
+++ b/src/main/java/jimmy/mcgymmy/model/ModelManager.java
@@ -5,12 +5,12 @@ import static java.util.Objects.requireNonNull;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Stack;
 import java.util.function.Predicate;
 import java.util.logging.Logger;
 
 import javafx.collections.ObservableList;
 import javafx.collections.transformation.FilteredList;
+import javafx.util.Pair;
 import jimmy.mcgymmy.commons.core.GuiSettings;
 import jimmy.mcgymmy.commons.core.LogsCenter;
 import jimmy.mcgymmy.commons.core.index.Index;
@@ -24,11 +24,12 @@ import jimmy.mcgymmy.model.food.Food;
 public class ModelManager implements Model {
     private static final Logger logger = LogsCenter.getLogger(ModelManager.class);
 
-    private final Stack<ReadOnlyMcGymmy> mcGymmyStack = new Stack<>();
+    private final History history = new History();
 
     private final McGymmy mcGymmy;
     private final UserPrefs userPrefs;
     private final FilteredList<Food> filteredFoodItems;
+    private Predicate<Food> filterPredicate;
 
     /**
      * Initializes a ModelManager with the given mcGymmy and userPrefs.
@@ -42,7 +43,8 @@ public class ModelManager implements Model {
         this.mcGymmy = new McGymmy(mcGymmy);
         this.userPrefs = new UserPrefs(userPrefs);
         filteredFoodItems = new FilteredList<>(this.mcGymmy.getFoodList());
-        filteredFoodItems.setPredicate(PREDICATE_SHOW_ALL_FOODS);
+        filterPredicate = PREDICATE_SHOW_ALL_FOODS;
+        filteredFoodItems.setPredicate(filterPredicate);
     }
 
     public ModelManager() {
@@ -93,8 +95,9 @@ public class ModelManager implements Model {
 
     @Override
     public void setMcGymmy(ReadOnlyMcGymmy mcGymmy) {
-        addCurrentStateToHistory();
+        saveCurrentStateToHistory();
         this.mcGymmy.resetData(mcGymmy);
+        updateFilterPredicate(PREDICATE_SHOW_ALL_FOODS);
     }
 
     @Override
@@ -106,30 +109,30 @@ public class ModelManager implements Model {
     @Override
     public void deleteFood(Index index) {
         logger.fine("Delete food at index: " + index.getOneBased());
-        addCurrentStateToHistory();
+        saveCurrentStateToHistory();
         mcGymmy.removeFood(index);
     }
 
     @Override
     public void addFood(Food food) {
         logger.fine("Add food:\n" + food.toString());
-        addCurrentStateToHistory();
+        saveCurrentStateToHistory();
         mcGymmy.addFood(food);
-        updateFilteredFoodList(PREDICATE_SHOW_ALL_FOODS);
+        updateFilterPredicate(PREDICATE_SHOW_ALL_FOODS);
     }
 
     @Override
     public void setFood(Index index, Food editedFood) {
         CollectionUtil.requireAllNonNull(index, editedFood);
         logger.fine("Change food at index " + index.getOneBased() + "to food:\n" + editedFood.toString());
-        addCurrentStateToHistory();
+        saveCurrentStateToHistory();
         mcGymmy.setFood(index, editedFood);
-        updateFilteredFoodList(PREDICATE_SHOW_ALL_FOODS);
+        updateFilterPredicate(PREDICATE_SHOW_ALL_FOODS);
     }
 
     @Override
     public boolean canUndo() {
-        return !mcGymmyStack.empty();
+        return !history.empty();
     }
 
     /**
@@ -138,20 +141,22 @@ public class ModelManager implements Model {
     @Override
     public void undo() {
         if (canUndo()) {
-            assert mcGymmyStack.size() > 0 : "McGymmyStack is empty";
-            mcGymmy.resetData(mcGymmyStack.pop());
-            updateFilteredFoodList(PREDICATE_SHOW_ALL_FOODS);
+            assert !history.empty() : "McGymmyStack is empty";
+            Pair<McGymmy, Predicate<Food>> prevMcGymmyPredicatePair = history.pop();
+            McGymmy prevMcGymmy = prevMcGymmyPredicatePair.getKey();
+            Predicate<Food> prevPredicate = prevMcGymmyPredicatePair.getValue();
+            mcGymmy.resetData(prevMcGymmy);
+            updateFilterPredicate(prevPredicate);
         }
     }
 
-    private void addCurrentStateToHistory() {
-        mcGymmyStack.push(new McGymmy(mcGymmy));
+    private void saveCurrentStateToHistory() {
+        history.save(this);
     }
 
     @Override
     public void clearFilteredFood() {
-        addCurrentStateToHistory();
-        Predicate<? super Food> filterPredicate = filteredFoodItems.getPredicate();
+        saveCurrentStateToHistory();
         List<Food> lst = new ArrayList<>();
         // prevent traversal error
         for (Food filteredFood : mcGymmy.getFoodList()) {
@@ -179,7 +184,17 @@ public class ModelManager implements Model {
     public void updateFilteredFoodList(Predicate<Food> predicate) {
         requireNonNull(predicate);
         logger.fine("Update predicate for filtered food list");
-        filteredFoodItems.setPredicate(predicate);
+        saveCurrentStateToHistory();
+        updateFilterPredicate(predicate);
+    }
+
+    private void updateFilterPredicate(Predicate<Food> predicate) {
+        filterPredicate = predicate;
+        filteredFoodItems.setPredicate(filterPredicate);
+    }
+
+    Predicate<Food> getFilterPredicate() {
+        return filterPredicate;
     }
 
     @Override

--- a/src/main/java/jimmy/mcgymmy/model/food/Food.java
+++ b/src/main/java/jimmy/mcgymmy/model/food/Food.java
@@ -126,12 +126,26 @@ public class Food {
         return Collections.unmodifiableSet(tags);
     }
 
-    public void addTag(Tag tag) {
-        tags.add(tag);
+    /**
+     * Adds a new tag to food
+     */
+    public Food addTag(Tag tag) {
+        Set<Tag> newTags = new HashSet<>(tags);
+        newTags.add(tag);
+        return new Food(name, protein, fat, carbs, newTags, date);
     }
 
-    public void removeTag(Tag tag) {
-        tags.remove(tag);
+    /**
+     * Removes a tag from food
+     */
+    public Food removeTag(Tag tag) {
+        Set<Tag> newTags = new HashSet<>(tags);
+        newTags.remove(tag);
+        return new Food(name, protein, fat, carbs, newTags, date);
+    }
+
+    public boolean hasTag(Tag tag) {
+        return tags.contains(tag);
     }
 
     public Date getDate() {

--- a/src/main/java/jimmy/mcgymmy/model/food/Food.java
+++ b/src/main/java/jimmy/mcgymmy/model/food/Food.java
@@ -128,6 +128,7 @@ public class Food {
 
     /**
      * Adds a new tag to food
+     * @return A new Food with the tag
      */
     public Food addTag(Tag tag) {
         Set<Tag> newTags = new HashSet<>(tags);
@@ -137,6 +138,7 @@ public class Food {
 
     /**
      * Removes a tag from food
+     * @return A new Food without the tag
      */
     public Food removeTag(Tag tag) {
         Set<Tag> newTags = new HashSet<>(tags);
@@ -144,6 +146,10 @@ public class Food {
         return new Food(name, protein, fat, carbs, newTags, date);
     }
 
+    /**
+     * Check if this food is already tagged with this tag
+     * @return True if this food is already tagged with this tag
+     */
     public boolean hasTag(Tag tag) {
         return tags.contains(tag);
     }

--- a/src/test/java/jimmy/mcgymmy/model/ModelManagerTest.java
+++ b/src/test/java/jimmy/mcgymmy/model/ModelManagerTest.java
@@ -161,7 +161,7 @@ public class ModelManagerTest {
 
     @Test
     public void undo_undoMultipleTimes_mcGymmyHasCorrectContent() {
-        Food newChickenRice = new FoodBuilder(CHICKEN_RICE).withDate("2020-04-20").build();
+        Food newChickenRice = new FoodBuilder(CHICKEN_RICE).withDate("2020-04-12").build();
         Food newNasiLemak = new FoodBuilder().withTags("Lunch").build();
 
         McGymmy expected1 = new McGymmyBuilder().build();

--- a/src/test/java/jimmy/mcgymmy/model/ModelManagerTest.java
+++ b/src/test/java/jimmy/mcgymmy/model/ModelManagerTest.java
@@ -2,6 +2,7 @@ package jimmy.mcgymmy.model;
 
 import static jimmy.mcgymmy.testutil.Assert.assertThrows;
 import static jimmy.mcgymmy.testutil.TypicalFoods.CHICKEN_RICE;
+import static jimmy.mcgymmy.testutil.TypicalFoods.DANISH_COOKIES;
 import static jimmy.mcgymmy.testutil.TypicalFoods.NASI_LEMAK;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -10,12 +11,14 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
+import java.util.function.Predicate;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import jimmy.mcgymmy.commons.core.GuiSettings;
 import jimmy.mcgymmy.commons.core.index.Index;
+import jimmy.mcgymmy.logic.commands.CommandTestUtil;
 import jimmy.mcgymmy.logic.predicate.NameContainsKeywordsPredicate;
 import jimmy.mcgymmy.model.food.Food;
 import jimmy.mcgymmy.testutil.FoodBuilder;
@@ -160,6 +163,28 @@ public class ModelManagerTest {
     }
 
     @Test
+    public void undo_undoAfterUpdateFilteredFoodList_modelManagerHasCorrectContent() {
+        McGymmy expectedMcGymmy = new McGymmyBuilder().withFood(CHICKEN_RICE).withFood(DANISH_COOKIES).build();
+        ModelManager expectedModelManager = new ModelManager(expectedMcGymmy, new UserPrefs());
+        modelManager.addFood(CHICKEN_RICE);
+        modelManager.addFood(DANISH_COOKIES);
+        CommandTestUtil.showFoodAtIndex(modelManager, Index.fromOneBased(2)); // updateFilterdFoodList
+        modelManager.undo();
+        assertEquals(modelManager, expectedModelManager);
+    }
+
+    @Test
+    public void undo_undoAfterClearFilteredFood_modelManagerHasCorrectContent() {
+        McGymmy expectedMcGymmy = new McGymmyBuilder().withFood(CHICKEN_RICE).withFood(DANISH_COOKIES).build();
+        ModelManager expectedModelManager = new ModelManager(expectedMcGymmy, new UserPrefs());
+        modelManager.addFood(CHICKEN_RICE);
+        modelManager.addFood(DANISH_COOKIES);
+        modelManager.clearFilteredFood();
+        modelManager.undo();
+        assertEquals(modelManager, expectedModelManager);
+    }
+
+    @Test
     public void undo_undoMultipleTimes_mcGymmyHasCorrectContent() {
         Food newChickenRice = new FoodBuilder(CHICKEN_RICE).withDate("2020-04-12").build();
         Food newNasiLemak = new FoodBuilder().withTags("Lunch").build();
@@ -191,6 +216,19 @@ public class ModelManagerTest {
         modelManager.undo();
         assertEquals(expected1, modelManager.getMcGymmy());
 
+    }
+
+    @Test
+    public void undo_updateFilteredFoodListWithSamePredicateMultipleTime_onlyUndoOnce() {
+        McGymmy expectedMcGymmy = new McGymmyBuilder().withFood(CHICKEN_RICE).withFood(DANISH_COOKIES).build();
+        ModelManager expectedModelManager = new ModelManager(expectedMcGymmy, new UserPrefs());
+        modelManager = new ModelManager(expectedMcGymmy, new UserPrefs());
+        Predicate<Food> predicate = food -> false;
+        modelManager.updateFilteredFoodList(predicate);
+        modelManager.updateFilteredFoodList(predicate);
+        modelManager.undo();
+        assertFalse(modelManager.canUndo());
+        assertEquals(modelManager, expectedModelManager);
     }
 
     @Test

--- a/src/test/java/jimmy/mcgymmy/model/food/FoodTest.java
+++ b/src/test/java/jimmy/mcgymmy/model/food/FoodTest.java
@@ -3,11 +3,14 @@ package jimmy.mcgymmy.model.food;
 import static jimmy.mcgymmy.testutil.Assert.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
 
+import jimmy.mcgymmy.model.tag.Tag;
 import jimmy.mcgymmy.testutil.Assert;
 import jimmy.mcgymmy.testutil.FoodBuilder;
+import jimmy.mcgymmy.testutil.TypicalFoods;
 
 
 public class FoodTest {
@@ -99,6 +102,39 @@ public class FoodTest {
 
         // different type -> returns false
         assertFalse(COMPARED_FOOD.equals(PROTEIN));
+    }
+
+    @Test
+    public void hasTag_tagInFood_returnsTrue() {
+        Food testFood = new FoodBuilder(TypicalFoods.CHICKEN_RICE).withTags("Lunch").build();
+        assertTrue(testFood.hasTag(new Tag("Lunch")));
+    }
+
+    @Test
+    public void hasTag_tagNotInFood_returnsFalse() {
+        Food testFood = new FoodBuilder(TypicalFoods.CHICKEN_RICE).withTags("Lunch").build();
+        assertFalse(testFood.hasTag(new Tag("Dinner")));
+    }
+
+    @Test
+    public void addTag_returnsNewFoodWithTag_oldFoodUnChanged() {
+        Tag initialTag = new Tag("Lunch");
+        Tag toBeAdded = new Tag("Dinner");
+        Food testFood = new FoodBuilder(TypicalFoods.CHICKEN_RICE).withTags("Lunch").build();
+        Food newFood = testFood.addTag(toBeAdded);
+        assertTrue(newFood.hasTag(toBeAdded));
+        assertTrue(newFood.hasTag(initialTag));
+        assertTrue(testFood.hasTag(initialTag));
+        assertFalse(testFood.hasTag(toBeAdded));
+    }
+
+    @Test
+    public void removeTag_returnsNewFoodWithoutTag_oldFoodUnChanged() {
+        Tag initialTag = new Tag("Lunch");
+        Food testFood = new FoodBuilder(TypicalFoods.CHICKEN_RICE).withTags("Lunch").build();
+        Food newFood = testFood.removeTag(initialTag);
+        assertFalse(newFood.hasTag(initialTag));
+        assertTrue(testFood.hasTag(initialTag));
     }
 
     @Test


### PR DESCRIPTION
- Change the location of the undo save point. It now saving state between each command execution (except help command).
- Make Food immutable: `addTag`, `removeTag` returns a new food item instead of editing the old one, so that food items can be stored to history properly.
- Create a `History` class to store past states.
- Add test to make sure that the updated undo feature works properly.
- Update documentation (I will do this in another PR)

*__NOTE__:* Consecutive command that doesn't effectively change the mcgymmy or the filteredFoodList's predicate will only be recorded once. 
For example:
* The user is only able to undo once after calling multiple `list` command consecutively (assuming that there is no command before that)
* Same behavior with `find [keyword]`
The predicates are compared using `Object#equals(Object)`

close #112, #115 