### PR TITLE
Limit size of Tags to 20 chars

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -178,6 +178,7 @@ Format: `tag INDEX -t TAG_NAME`
 * `TAG_NAME` is case-sensitive.
 * The index refers to the index number shown in the displayed food list.
 * The index **must be a positive integer** 1, 2, 3, …​
+* Tags for food items must be less than 50 characters.
 
 </div>
 

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -178,7 +178,7 @@ Format: `tag INDEX -t TAG_NAME`
 * `TAG_NAME` is case-sensitive.
 * The index refers to the index number shown in the displayed food list.
 * The index **must be a positive integer** 1, 2, 3, …​
-* Tags for food items must be less than 50 characters.
+* Tags for food items must be less than 20 characters.
 
 </div>
 

--- a/src/main/java/jimmy/mcgymmy/model/tag/Tag.java
+++ b/src/main/java/jimmy/mcgymmy/model/tag/Tag.java
@@ -10,8 +10,8 @@ import jimmy.mcgymmy.commons.util.AppUtil;
  */
 public class Tag {
 
-    public static final String MESSAGE_CONSTRAINTS = "Tags names should be alphanumeric and less than 50 characters";
-    public static final String VALIDATION_REGEX = "\\p{Alnum}{1,50}";
+    public static final String MESSAGE_CONSTRAINTS = "Tags names should be alphanumeric and less than 20 characters";
+    public static final String VALIDATION_REGEX = "\\p{Alnum}{1,20}";
 
     public final String tagName;
 

--- a/src/main/java/jimmy/mcgymmy/model/tag/Tag.java
+++ b/src/main/java/jimmy/mcgymmy/model/tag/Tag.java
@@ -10,8 +10,8 @@ import jimmy.mcgymmy.commons.util.AppUtil;
  */
 public class Tag {
 
-    public static final String MESSAGE_CONSTRAINTS = "Tags names should be alphanumeric";
-    public static final String VALIDATION_REGEX = "\\p{Alnum}+";
+    public static final String MESSAGE_CONSTRAINTS = "Tags names should be alphanumeric and less than 50 characters";
+    public static final String VALIDATION_REGEX = "\\p{Alnum}{1,50}";
 
     public final String tagName;
 

--- a/src/test/java/jimmy/mcgymmy/model/tag/TagTest.java
+++ b/src/test/java/jimmy/mcgymmy/model/tag/TagTest.java
@@ -24,7 +24,7 @@ public class TagTest {
 
         //Invalid testcases
         assertThrows(NullPointerException.class, () -> new Tag(null)); // null tag name
-        assertFalse(Tag.isValidTagName("123456789012345678901234567890123456789012345678901")); // 51 chars
+        assertFalse(Tag.isValidTagName("123456789012345678901")); // 21 chars
         assertFalse(Tag
                 .isValidTagName("123456789012345678901234567890123456789012345678901234567890")); // 60 chars
         assertFalse(Tag.isValidTagName("asdsafdfs12345$$$@#$!^#$")); //Alphanumeric with symbol
@@ -33,6 +33,7 @@ public class TagTest {
         //ValidTagNames
         assertTrue(Tag.isValidTagName("asdsafdfs")); //Alphabets
         assertTrue(Tag.isValidTagName("asdsafdfs12345")); //Alphanumeric
+        assertTrue(Tag.isValidTagName("12345678901234567890")); //20 chars
 
     }
 

--- a/src/test/java/jimmy/mcgymmy/model/tag/TagTest.java
+++ b/src/test/java/jimmy/mcgymmy/model/tag/TagTest.java
@@ -1,6 +1,8 @@
 package jimmy.mcgymmy.model.tag;
 
 import static jimmy.mcgymmy.testutil.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
 
@@ -19,8 +21,19 @@ public class TagTest {
 
     @Test
     public void isValidTagName() {
-        // null tag name
-        assertThrows(NullPointerException.class, () -> Tag.isValidTagName(null));
+
+        //Invalid testcases
+        assertThrows(NullPointerException.class, () -> new Tag(null)); // null tag name
+        assertFalse(Tag.isValidTagName("123456789012345678901234567890123456789012345678901")); // 51 chars
+        assertFalse(Tag
+                .isValidTagName("123456789012345678901234567890123456789012345678901234567890")); // 60 chars
+        assertFalse(Tag.isValidTagName("asdsafdfs12345$$$@#$!^#$")); //Alphanumeric with symbol
+        assertFalse(Tag.isValidTagName("@#$!^#$")); //Symbols
+
+        //ValidTagNames
+        assertTrue(Tag.isValidTagName("asdsafdfs")); //Alphabets
+        assertTrue(Tag.isValidTagName("asdsafdfs12345")); //Alphanumeric
+
     }
 
 }


### PR DESCRIPTION
To prevent overflow for characters of tag, Limit the tag to 20 characters

At the smallest size of the window, it is still possible to fit tags with 20 characters, thus 20 characters will be the limit
![image](https://user-images.githubusercontent.com/10459011/97769471-5dd84200-1b66-11eb-9fa1-87a850207f20.png)
