### PR TITLE
Change Name of arguments in the MacroNutrient Parameters

### DIFF
--- a/src/main/java/jimmy/mcgymmy/logic/commands/AddCommand.java
+++ b/src/main/java/jimmy/mcgymmy/logic/commands/AddCommand.java
@@ -30,21 +30,21 @@ public class AddCommand extends Command {
             ParserUtil::parseName
     );
     private OptionalParameter<Protein> proteinParameter = this.addOptionalParameter(
-            "protein value",
+            "protein",
             "p",
             "Protein value of food (g)",
             "10",
             ParserUtil::parseProtein
     );
     private OptionalParameter<Fat> fatParameter = this.addOptionalParameter(
-            "fat value",
+            "fat",
             "f",
             "Fat value of food (g)",
             "10",
             ParserUtil::parseFat
     );
     private OptionalParameter<Carbohydrate> carbParameter = this.addOptionalParameter(
-            "carb value",
+            "carb",
             "c",
             "Carbohydrate value of food (g)",
             "10",

--- a/src/main/java/jimmy/mcgymmy/logic/commands/EditCommand.java
+++ b/src/main/java/jimmy/mcgymmy/logic/commands/EditCommand.java
@@ -46,21 +46,21 @@ public class EditCommand extends Command {
             ParserUtil::parseName
     );
     private OptionalParameter<Protein> proteinParameter = this.addOptionalParameter(
-            "protein value",
+            "protein",
             "p",
             "Protein value of food (g)",
             "10",
             ParserUtil::parseProtein
     );
     private OptionalParameter<Fat> fatParameter = this.addOptionalParameter(
-            "fat value",
+            "fat",
             "f",
             "Fat value of food (g)",
             "10",
             ParserUtil::parseFat
     );
     private OptionalParameter<Carbohydrate> carbParameter = this.addOptionalParameter(
-            "carb value",
+            "carb",
             "c",
             "Carbohydrate value of food (g)",
             "10",


### PR DESCRIPTION
Change Name of arguments in the MacroNutrient Parameters

Remove the Value to avoid ambiguity of arguments,