### PR TITLE
Fix minor bugs in Macro

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -124,8 +124,14 @@ We will follow the following convention for each command's format:
 * Items with `…`​ after them can be used multiple times including zero times.<br>
   e.g. `[commnand;]…​` can be used as ` ` (i.e. 0 times), `delete 1;`, `delete 2; delete 1;` etc.
 
-* Parameters and optional parameters can be in any order.<br>
+* Parameters and optional parameters with flags can be in any order.<br>
   e.g. if the command specifies `-c CARBS -p PROTEIN [-f FATS]`, `-p PROTEIN [-f FATS] -c CARBS` is also acceptable.
+
+* Flag-less parameters always have to be the first parameter after the command word.<br>
+  e.g. in `edit 1 -n chicken`, the flag-less parameter is `1` and the `n` parameter is `chicken`. However for `edit -n chicken 1`, there is no flag-less parameter, and the `n` parameter is `chicken 1`.
+  
+* Entering the same parameter twice will concatenate the inputs.<br>
+  e.g. in `add -n potato -n chip`, the `n` parameters will be concatenated to `potato chip`, and a new item with the name `potato chip` will be created.
 
 </div>
 

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -417,7 +417,7 @@ Format: `macro MACRONAME FLAG_1 FLAG_2 ... ; COMMAND_1 PARAMETERS_TO_COMMAND_1; 
 
 * If any of the jargon below seem unclear, refer to *How to intepret the each command's format* under section *5. Features* above.
 
-* Create a macro with name `MACRONAME` which takes in parameters `FLAG_1 FLAG_2...` which executes `COMMAND_1; COMMAND_2; ...`.
+* Creates a macro with name `MACRONAME` which takes in parameters `FLAG_1 FLAG_2...` which executes `COMMAND_1; COMMAND_2; ...`.
 
 * Parameters to the macro can be substituted in the `PARAMETERS_TO_COMMAND` using the syntax: `\FLAG_NAME`.
 
@@ -438,6 +438,15 @@ Examples:
 * `macro addFoodWithFries; add -n \$ ; add -n \$ With Fries`
     * Example usage of this macro: `addFoodWithFries Ice Cream`
     * The following commands will be executed by the macro: `add -n Ice Cream` and `add -n Ice Cream With Fries`.
+
+<div markdown="span" class="alert alert-primary">
+
+:bulb: **Tip:** Be careful when creating a macro!
+* It is possible to create a macro with errors!
+* The commands in the macro will only be checked for errors when you run the macro itself.
+* e.g. Entering `macro test; add` will create a new macro, but every time you execute the macro `test`, the error message from `add` telling you it requires the name parameter will be shown.
+
+</div>
 
 ![Macro command example](images/CommandImagesForUG/Macro.png)
 

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -115,7 +115,7 @@ We will follow the following convention for each command's format:
 * Words in `UPPER_CASE` are the parameters to be supplied by you.<br>
   e.g. in `add -n NAME -p PROTEIN`, `NAME` and `PROTEIN` are parameters which can be used as `add bacon -p 200`.
   
-* Prefixes that precede parameters represent flags that indicate which parameter is being referenced. Parameters that are not preceded by a flag are denoted as flag-less parameters. For simplicity, the [flag + parameter input] together will be referenced as a single parameter.<br>
+* Prefixes that precede parameters represent *flags* that indicate which parameter is being referenced. Parameters that are not preceded by a flag are denoted as *flag-less* parameters. For simplicity, the [flag + parameter input] together will be referenced as a single parameter.<br>
   e.g. in `find example -t lunch`, `example` represents a flag-less parameter while `-t lunch` is referred as a parameter with flag `-t` and parameter input `lunch`.
 
 * Items in square brackets are optional.<br>
@@ -415,6 +415,8 @@ Format: `macro MACRONAME FLAG_1 FLAG_2 ... ; COMMAND_1 PARAMETERS_TO_COMMAND_1; 
 
 :information_source:
 
+* If any of the jargon below seem unclear, refer to *How to intepret the each command's format* under section *5. Features* above.
+
 * Create a macro with name `MACRONAME` which takes in parameters `FLAG_1 FLAG_2...` which executes `COMMAND_1; COMMAND_2; ...`.
 
 * Parameters to the macro can be substituted in the `PARAMETERS_TO_COMMAND` using the syntax: `\FLAG_NAME`.
@@ -429,9 +431,9 @@ Format: `macro MACRONAME FLAG_1 FLAG_2 ... ; COMMAND_1 PARAMETERS_TO_COMMAND_1; 
 
 Examples:
 * `macro addWith100cal p ; add -n \$ -c 100 -p \p`
-    * Example usage of this macro: `addWith100cal Banana -p 2000`
-    * The following command will be executed by the macro: `add -n Banana -c 100 -p 2000`
-    * i.e. in `add -n \$ -c 100 -p \p`, `\$` and `\p` will be substituted with Banana and 2000 respectively.
+    * Example usage of this macro: `addWith100cal Banana -p 200`
+    * The following command will be executed by the macro: `add -n Banana -c 100 -p 200`
+    * i.e. in `add -n \$ -c 100 -p \p`, `\$` and `\p` will be substituted with Banana and 200 respectively.
 
 * `macro addFoodWithFries; add -n \$ ; add -n \$ With Fries`
     * Example usage of this macro: `addFoodWithFries Ice Cream`

--- a/src/main/java/jimmy/mcgymmy/logic/parser/McGymmyParser.java
+++ b/src/main/java/jimmy/mcgymmy/logic/parser/McGymmyParser.java
@@ -99,7 +99,7 @@ public class McGymmyParser {
             return MacroRunner.asCommandInstance(macro, args);
         } catch (org.apache.commons.cli.ParseException e) {
             String formattedHelp = ParserUtil.getUsageFromHelpFormatter(commandName, "", options);
-            throw new ParseException(formattedHelp);
+            throw new ParseException(e.getMessage() + "\n" + formattedHelp);
         }
     }
 }

--- a/src/main/java/jimmy/mcgymmy/logic/parser/PrimitiveCommandHelpUtil.java
+++ b/src/main/java/jimmy/mcgymmy/logic/parser/PrimitiveCommandHelpUtil.java
@@ -18,6 +18,17 @@ import jimmy.mcgymmy.logic.parser.parameter.ParameterSet;
  * A class to generate various help strings for primitive commands.
  */
 public class PrimitiveCommandHelpUtil {
+    /* In the future, instead of these constants we could create a method
+    that inserts help strings for commands that are not stored in the table,
+    but should also be listed using `help`. But for now, YAGNI. */
+    private static final String MACRO_HELP_STRING = "Add a macro to run several commands in succession.";
+    // not splitting up usage with new lines because that may confuse user.
+    private static final String MACRO_USAGE_STRING = "usage: macro"
+            + "\nMACRONAME FLAG_1 FLAG_2 ... ; "
+            + "COMMAND_1 PARAMETERS_TO_COMMAND_1; "
+            + "[COMMAND_2 PARAMETERS_TO_COMMAND_2; ...]"
+            + "\n\nEXAMPLE: macro breakfast; add -n toast -c 10; add -n egg -p 10";
+
     private final Map<String, Supplier<Command>> commandTable;
     private final Map<String, String> commandDescriptionTable;
 
@@ -57,6 +68,7 @@ public class PrimitiveCommandHelpUtil {
         for (String commandName : commandDescriptionTable.keySet()) {
             result.append(String.format("\n%s: %s", commandName, commandDescriptionTable.get(commandName)));
         }
+        result.append("\nmacro: ").append(MACRO_HELP_STRING);
         return result.toString();
     }
 
@@ -67,6 +79,9 @@ public class PrimitiveCommandHelpUtil {
      */
     public CommandExecutable newHelpCommand(String commandName) {
         return model -> {
+            if (commandName.equals("macro")) {
+                return new CommandResult(MACRO_USAGE_STRING);
+            }
             if (!commandTable.containsKey(commandName)) {
                 throw new CommandException("Error: That command does not exist.");
             }

--- a/src/test/java/jimmy/mcgymmy/logic/parser/McGymmyParserTest.java
+++ b/src/test/java/jimmy/mcgymmy/logic/parser/McGymmyParserTest.java
@@ -1,9 +1,11 @@
 package jimmy.mcgymmy.logic.parser;
 
 import static jimmy.mcgymmy.testutil.Assert.assertThrows;
+import static jimmy.mcgymmy.testutil.TypicalMacros.TEST_MACRO;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import org.junit.jupiter.api.Test;
 
@@ -44,6 +46,18 @@ public class McGymmyParserTest {
         mcGymmyParser.setMacroList(mcGymmyParser.getMacroList().withNewMacro(dummyMacro));
         // this should not throw any errors
         mcGymmyParser.parse("test");
+    }
+
+    @Test
+    public void invalidMacro_showsUsageToUser() throws Exception {
+        McGymmyParser mcGymmyParser = new McGymmyParser();
+        mcGymmyParser.setMacroList(mcGymmyParser.getMacroList().withNewMacro(TEST_MACRO));
+        try {
+            mcGymmyParser.parse("test");
+            fail("ParseException not thrown");
+        } catch (ParseException e) {
+            assertTrue(e.getMessage().contains("Missing required"));
+        }
     }
 
     @Test

--- a/src/test/java/jimmy/mcgymmy/logic/parser/PrimitiveCommandHelpUtilTest.java
+++ b/src/test/java/jimmy/mcgymmy/logic/parser/PrimitiveCommandHelpUtilTest.java
@@ -1,0 +1,62 @@
+package jimmy.mcgymmy.logic.parser;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import jimmy.mcgymmy.logic.commands.CommandResult;
+import jimmy.mcgymmy.model.Model;
+import jimmy.mcgymmy.model.ModelManager;
+
+// integration tests for HelpCommand
+public class PrimitiveCommandHelpUtilTest {
+    private PrimitiveCommandHelpUtil helpUtil;
+    private Model model;
+
+    @BeforeEach
+    public void setUp() {
+        PrimitiveCommandParser parser = new PrimitiveCommandParser();
+        helpUtil = new PrimitiveCommandHelpUtil(parser.getCommandTable(), parser.getCommandDescriptionTable());
+        model = new ModelManager();
+    }
+
+    @Test
+    public void noArguments_correctOutput() throws Exception {
+        CommandResult commandResult = helpUtil.newHelpCommand().execute(model);
+        /* Checking for contained keywords: If we check for the whole string,
+           minor format changes might break the test. Checking for keywords
+           should suffice. */
+        // Check if 'for more info...' string is included
+        assertTrue(commandResult.getFeedbackToUser().contains("help [COMMAND]"));
+        // Equivalence partition: commands in commandTable
+        assertTrue(commandResult.getFeedbackToUser().contains("add: "));
+        assertTrue(commandResult.getFeedbackToUser().contains("list: "));
+        // Equivalence partition: special case macro command
+        assertTrue(commandResult.getFeedbackToUser().contains("macro: "));
+    }
+
+    @Test
+    public void argumentFromCommandTable_correctOutput() throws Exception {
+        // Equivalence partition: checking 1 command from the table should suffice.
+        CommandResult commandResult = helpUtil.newHelpCommand("add").execute(model);
+        // Check 'usage:' is included
+        assertTrue(commandResult.getFeedbackToUser().contains("usage"));
+        // Check if parameter string for 1 parameter is included (same partition as other parameters).
+        assertTrue(commandResult.getFeedbackToUser().contains("-n"));
+        // Check 'EXAMPLE' is included
+        assertTrue(commandResult.getFeedbackToUser().contains("EXAMPLE"));
+    }
+
+    @Test
+    public void argumentIsMacro_correctOutput() throws Exception {
+        // Equivalence partition: checking special case of macro command.
+        CommandResult commandResult = helpUtil.newHelpCommand("macro").execute(model);
+        // Check 'usage:' is included
+        assertTrue(commandResult.getFeedbackToUser().contains("usage"));
+        // Check if format string is included.
+        assertTrue(commandResult.getFeedbackToUser().contains("MACRONAME"));
+        // Check 'EXAMPLE' is included
+        assertTrue(commandResult.getFeedbackToUser().contains("EXAMPLE"));
+    }
+}


### PR DESCRIPTION
Close #157, #188, #167, #199, #162, #187, #159 

- [x] Fix macro parse error not showing 'usage' string: #157 
- [x] Fix macro not showing up in `help` command: #188 
- [x] Add message in UG to explain key terms: #167 
- [x] (not macro related but) Add explanation on multiple repeated parameters in UG: #199 #162 maybe #163
- [x] (not macro related but) Add clarification on flag-less parameters in UG: #187
- [x] Explain to users in UG you can create a macro with invalid parameters and error is only thrown when its run: #159 