### PR TITLE
Change undo behavior

### DIFF
--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -309,8 +309,7 @@ The following sequence diagram shows how the import operation works:
 
 The proposed undo mechanism is facilitated by `ModelManager` and `History`.
 `History` pairs `ReadOnlyMcGymmy` and `Predicate<Food>` gotten from `ModelManager` into a pair, then store multiple pairs of different versions in a stack, with the most recent version on top.
-Whenever there is a change to either `ModelManager`'s data or filter predicate, `ModelManager` will pass itself into `History` to be checked and saved in the stack.
-If `History` recognizes there is no change between the current state and the previous state, it will not save the current state to its stack.
+Whenever there is a change to either `ModelManager`'s data, filter predicate, or macro list, `ModelManager` will pass itself into `History` to be saved into the stack.
 Additionally, `ModelManager` implements the following operations:
 
 * `ModelManager#canUndo()` - Checks if there is any older state stored in history.

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -395,8 +395,6 @@ Format: `undo`
 * Help command will be ignored when undoing. 
 For example, if the user calls the following commands in sequence:
 `add -n Burger`, `help edit`, `undo`, the undo command will undo the adding operation, not the help one.
-* Calling `undo` after 2 or more consecutive `list` calls only undoes the listing operation once.
-* Calling `undo` after 2 or more consecutive `find` calls with the same sequence of keyword only undoes the find operation once.
 * All additional input after the *command word* `undo` will be ignored. E.g. `undo` and `undo 123` will have the same effect.
 
 ![Undo command example](images/CommandImagesForUG/Undo.png)

--- a/src/main/java/jimmy/mcgymmy/model/History.java
+++ b/src/main/java/jimmy/mcgymmy/model/History.java
@@ -15,30 +15,11 @@ class History {
         stack = new Stack<>();
     }
 
-    private boolean checkIfSameWithPreviousState(McGymmy otherMcGymmy, Predicate<Food> otherPredicate,
-                                                 MacroList otherMacroList) {
-        if (stack.empty()) {
-            return false;
-        }
-
-        McGymmy mcGymmy = getMcGymmy();
-        Predicate<Food> predicate = getPredicate();
-        MacroList macroList = getMacroList();
-
-        boolean isSameMcGymmy = otherMcGymmy.equals(mcGymmy);
-        boolean isSamePredicate = otherPredicate.equals(predicate);
-        boolean isSameMacroList = otherMacroList.equals(macroList);
-        return isSameMcGymmy && isSamePredicate && isSameMacroList;
-    }
-
     void save(ModelManager modelManager) {
         McGymmy mcGymmy = new McGymmy(modelManager.getMcGymmy());
         Predicate<Food> predicate = modelManager.getFilterPredicate();
         MacroList macroList = modelManager.getMacroList();
-        boolean isSameWithPreviousState = checkIfSameWithPreviousState(mcGymmy, predicate, macroList);
-        if (!isSameWithPreviousState) {
-            stack.push(new Pair<>(mcGymmy, new Pair<>(predicate, macroList)));
-        }
+        stack.push(new Pair<>(mcGymmy, new Pair<>(predicate, macroList)));
     }
 
     boolean empty() {

--- a/src/main/java/jimmy/mcgymmy/model/History.java
+++ b/src/main/java/jimmy/mcgymmy/model/History.java
@@ -15,6 +15,9 @@ class History {
         stack = new Stack<>();
     }
 
+    /**
+     * Saves the mcGymmy, predicate and macrolist of <code>ModelManager</code> to history
+     */
     void save(ModelManager modelManager) {
         McGymmy mcGymmy = new McGymmy(modelManager.getMcGymmy());
         Predicate<Food> predicate = modelManager.getFilterPredicate();
@@ -22,26 +25,33 @@ class History {
         stack.push(new Pair<>(mcGymmy, new Pair<>(predicate, macroList)));
     }
 
+    /**
+     * @return True if the history is empty
+     */
     boolean empty() {
         return stack.empty();
     }
 
+    /**
+     * Get the previous state from history
+     * @throws EmptyStackException
+     */
     void pop() throws EmptyStackException {
         assert !stack.empty() : "History is empty";
         stack.pop();
     }
 
-    McGymmy getMcGymmy() throws EmptyStackException {
+    McGymmy peekMcGymmy() throws EmptyStackException {
         assert !stack.empty() : "History is empty";
         return stack.peek().getKey();
     }
 
-    Predicate<Food> getPredicate() throws EmptyStackException {
+    Predicate<Food> peekPredicate() throws EmptyStackException {
         assert !stack.empty() : "History is empty";
         return stack.peek().getValue().getKey();
     }
 
-    MacroList getMacroList() throws EmptyStackException {
+    MacroList peekMacroList() throws EmptyStackException {
         assert !stack.empty() : "History is empty";
         return stack.peek().getValue().getValue();
     }

--- a/src/main/java/jimmy/mcgymmy/model/ModelManager.java
+++ b/src/main/java/jimmy/mcgymmy/model/ModelManager.java
@@ -228,10 +228,8 @@ public class ModelManager implements Model {
     public void updateFilteredFoodList(Predicate<Food> predicate) {
         requireNonNull(predicate);
         logger.fine("Update predicate for filtered food list");
-        if (!predicate.equals(filterPredicate)) {
-            saveCurrentStateToHistory();
-            updateFilterPredicate(predicate);
-        }
+        saveCurrentStateToHistory();
+        updateFilterPredicate(predicate);
     }
 
     private void updateFilterPredicate(Predicate<Food> predicate) {

--- a/src/main/java/jimmy/mcgymmy/model/ModelManager.java
+++ b/src/main/java/jimmy/mcgymmy/model/ModelManager.java
@@ -185,9 +185,9 @@ public class ModelManager implements Model {
     public void undo() {
         if (canUndo()) {
             assert !history.empty() : "McGymmyStack is empty";
-            McGymmy prevMcGymmy = history.getMcGymmy();
-            Predicate<Food> prevPredicate = history.getPredicate();
-            MacroList macroList = history.getMacroList();
+            McGymmy prevMcGymmy = history.peekMcGymmy();
+            Predicate<Food> prevPredicate = history.peekPredicate();
+            MacroList macroList = history.peekMacroList();
             history.pop();
             mcGymmy.resetData(prevMcGymmy);
             updateFilterPredicate(prevPredicate);

--- a/src/test/java/jimmy/mcgymmy/model/ModelManagerTest.java
+++ b/src/test/java/jimmy/mcgymmy/model/ModelManagerTest.java
@@ -178,12 +178,12 @@ public class ModelManagerTest {
     @Test
     public void undo_undoAfterClearFilteredFood_modelManagerHasCorrectContent() {
         McGymmy expectedMcGymmy = new McGymmyBuilder().withFood(CHICKEN_RICE).withFood(DANISH_COOKIES).build();
-        ModelManager expectedModelManager = new ModelManager(expectedMcGymmy, new UserPrefs());
         modelManager.addFood(CHICKEN_RICE);
         modelManager.addFood(DANISH_COOKIES);
+        modelManager.updateFilteredFoodList(food -> food.equals(CHICKEN_RICE));
         modelManager.clearFilteredFood();
         modelManager.undo();
-        assertEquals(modelManager, expectedModelManager);
+        assertEquals(modelManager.getMcGymmy(), expectedMcGymmy);
     }
 
     @Test

--- a/src/test/java/jimmy/mcgymmy/model/ModelManagerTest.java
+++ b/src/test/java/jimmy/mcgymmy/model/ModelManagerTest.java
@@ -270,7 +270,7 @@ public class ModelManagerTest {
     }
 
     @Test
-    public void undo_updateFilteredFoodListWithSamePredicateMultipleTime_onlyUndoOnce() {
+    public void undo_updateFilteredFoodListWithSamePredicateMultipleTime_undoMultipleTimes() {
         McGymmy expectedMcGymmy = new McGymmyBuilder().withFood(CHICKEN_RICE).withFood(DANISH_COOKIES).build();
         ModelManager expectedModelManager = new ModelManager(expectedMcGymmy, new UserPrefs());
         modelManager = new ModelManager(expectedMcGymmy, new UserPrefs());
@@ -278,7 +278,8 @@ public class ModelManagerTest {
         modelManager.updateFilteredFoodList(predicate);
         modelManager.updateFilteredFoodList(predicate);
         modelManager.undo();
-        assertFalse(modelManager.canUndo());
+        assertTrue(modelManager.canUndo());
+        modelManager.undo();
         assertEquals(modelManager, expectedModelManager);
     }
 


### PR DESCRIPTION
- Update `History`'s behavior such that it will save the ModelManager no matter what. For example: calling `list` 2 times can be undone twice, instead of one as before.
- Update the undo sections in both UG and DG
Reason: this is more intuitive (and most browsers are implemented this way)

close #185 